### PR TITLE
Resolve css-loader error 'Promise is not defined.' during build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "typescript": "^1.8.10",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.14",
-    "webpack-dev-server": "^1.14.1"
+    "webpack-dev-server": "^1.14.1",
+    "es6-promise": "~3.2.1"
   },
   "devDependencies": {
     "babel-core": "^6.7.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 /*eslint-env node */
 
+require('es6-promise').polyfill();
 var webpack = require('webpack');
 var path = require('path');
 


### PR DESCRIPTION
Looks like this behavior crops up on a variety of different node versions.

http://github.com/webpack/css-loader/issues/144

ERROR in ./~/css-loader!./src/css/main.css
Module build failed: ReferenceError: Promise is not defined
    at LazyResult.async (/home/chadical/src/interactive-console/node_modules/css-loader/node_modules/postcss/lib/lazy-result.js:237:31)
    at LazyResult.then (/home/chadical/src/interactive-console/node_modules/css-loader/node_modules/postcss/lib/lazy-result.js:141:21)
    at processCss (/home/chadical/src/interactive-console/node_modules/css-loader/lib/processCss.js:198:5)
    at Object.module.exports (/home/chadical/src/interactive-console/node_modules/css-loader/lib/loader.js:24:2)
 @ ./src/css/main.css 4:14-78 13:2-17:4 14:20-84
